### PR TITLE
Fix wrong xmlns for optional Custom Thumbnail part

### DIFF
--- a/help/getting-started-wknd-tutorial-develop/project-setup.md
+++ b/help/getting-started-wknd-tutorial-develop/project-setup.md
@@ -617,7 +617,7 @@ This is an optional task but its nice to easily identify your custom code packag
    ```xml
 
    <?xml version="1.0" encoding="UTF-8"?>
-   <jcr:root xmlns:vlt="https://www.day.com/jcr/vault/1.0" xmlns:jcr="https://www.jcp.org/jcr/1.0" xmlns:nt="https://www.jcp.org/jcr/nt/1.0">
+   <jcr:root xmlns:vlt="http://www.day.com/jcr/vault/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0">
        <thumbnail.png/>
    </jcr:root>
 


### PR DESCRIPTION
The contents of .content.xml were wrong, because the xmlns entries (with https:// ) result in an error while uploading to package to crx.
the final .content.xml's within the repository are using also http:// instead of https://