### PR TITLE
Fix minor error in policy path

### DIFF
--- a/help/getting-started-wknd-tutorial-develop/pages-templates.md
+++ b/help/getting-started-wknd-tutorial-develop/pages-templates.md
@@ -265,7 +265,7 @@ The next few steps will take place using the Eclipse IDE, but could be doing usi
 
    Confirm the **Import from Repository** dialog and click **Finish**. You should now see the `article-page-template` beneath the `templates` folder.
 
-4. Repeat the steps to import content but select the **policies** node located at `/conf/wknd/settings/wcm/templates/policies`.
+4. Repeat the steps to import content but select the **policies** node located at `/conf/wknd/settings/wcm/policies`.
 
    ![Eclipse import policies](assets/pages-templates/policies-article-page-template.png)
 


### PR DESCRIPTION
The section _Saving Configurations to Source Control_ outlines the steps necessary to download template and policy configuration as `.content.xml` files. The path to policies is different from the one in the project structure. I believe it should be `/conf/wknd/settings/wcm/policies` (`policies` is a sibling of `templates`, not its child). Depending on the exact tools used, this could be unnoticeable or a bit of a distraction.