### PR TITLE
Updated spa npm packages names as changed by Adobe on 24.Aug.2020

### DIFF
--- a/help/spa-angular-tutorial/integrate-spa.md
+++ b/help/spa-angular-tutorial/integrate-spa.md
@@ -99,8 +99,8 @@ Next, inspect the `ui.frontend` module to understand the SPA that has been auto-
 
     ```json
     "@adobe/cq-angular-editable-components": "^2.0.2",
-    "@adobe/cq-spa-component-mapping": "^1.0.3",
-    "@adobe/cq-spa-page-model-manager": "^1.1.3",
+    "@adobe/aem-spa-component-mapping": "^1.0.0",
+    "@adobe/aem-spa-page-model-manager": "^1.0.0",
     ```
 
     The above modules make up the [AEM SPA Editor JS SDK](https://docs.adobe.com/content/help/en/experience-manager-65/developing/headless/spas/spa-blueprint.html) and provide the functionality to make it possible to map SPA Components to AEM Components.
@@ -133,7 +133,7 @@ Next, inspect the `ui.frontend` module to understand the SPA that has been auto-
 
     ```js
     import { Constants } from '@adobe/cq-angular-editable-components';
-    import { ModelManager } from '@adobe/cq-spa-page-model-manager';
+    import { ModelManager } from '@adobe/aem-spa-page-model-manager';
     import { Component } from '@angular/core';
 
     @Component({

--- a/help/spa-react-tutorial/integrate-spa.md
+++ b/help/spa-react-tutorial/integrate-spa.md
@@ -94,9 +94,9 @@ Next, inspect the `ui.frontend` module to understand the SPA that has been auto-
 4. There are also three dependencies prefixed with `@adobe`:
 
     ```json
-    "@adobe/cq-react-editable-components": "^1.2.0",
-    "@adobe/cq-spa-component-mapping": "^1.0.3",
-    "@adobe/cq-spa-page-model-manager": "^1.1.0",
+    "@adobe/aem-react-editable-components": "^1.0.0",
+    "@adobe/aem-spa-component-mapping": "^1.0.0",
+    "@adobe/aem-spa-page-model-manager": "^1.0.0",
     ```
 
     The above modules make up the [AEM SPA Editor JS SDK](https://docs.adobe.com/content/help/en/experience-manager-65/developing/headless/spas/spa-blueprint.html) and provide the functionality to make it possible to map SPA Components to AEM Components.
@@ -184,7 +184,7 @@ Next, add a new component to the SPA and deploy the changes to a local AEM insta
 5. Make the following updates to `App.js` to include the static `Header`:
 
     ```diff
-      import { Page, withModel } from '@adobe/cq-react-editable-components';
+      import { Page, withModel } from '@adobe/aem-react-editable-components';
       import React from 'react';
     + import Header from './components/Header/Header';
 


### PR DESCRIPTION
Based on the changes made by Adobe team on npm packages, updated docs to reflect the new package names to be used from:
```
@adobe/cq-react-editable-components
@adobe/cq-spa-component-mapping
@adobe/cq-spa-page-model-manager
```

to

```
@adobe/aem-react-editable-components
@adobe/aem-spa-component-mapping
@adobe/aem-spa-page-model-manager
```
if not, builds will fail. 