### PR TITLE
Fix policies folder location

### DIFF
--- a/help/spa-angular-tutorial/map-components.md
+++ b/help/spa-angular-tutorial/map-components.md
@@ -474,7 +474,7 @@ The next few steps will take place using the Visual Studio Code IDE and [VSCode 
 
    ![VSCode import template](assets/map-components/import-aem-servervscode.png)
 
-4. Repeat the steps to import content but select the **policies** folder located at `/conf/wknd-spa-angular/settings/wcm/templates/policies`.
+4. Repeat the steps to import content but select the **policies** folder located at `/conf/wknd-spa-angular/settings/wcm/policies`.
 
 5. Inspect the `filter.xml` file located at `ui.content/src/main/content/META-INF/vault/filter.xml`.
 


### PR DESCRIPTION
The location indicated of the policies the policies sibling of the templates folder and not children of it.