### PR TITLE
Tutorial correction (org.apache.commons.lang.StringUtils)

### DIFF
--- a/help/getting-started-wknd-tutorial-develop/project-archetype/component-basics.md
+++ b/help/getting-started-wknd-tutorial-develop/project-archetype/component-basics.md
@@ -180,7 +180,7 @@ Next, we will make some updates to the `HelloWorldModel` Sling Model in order to
 1. Add the following import statements:
 
     ```java
-    import org.apache.commons.lang.StringUtils;
+    import org.apache.commons.lang3.StringUtils;
     import org.apache.sling.models.annotations.DefaultInjectionStrategy;
     ```
 


### PR DESCRIPTION
"import org.apache.commons.lang.StringUtils;" is deprecated.
"import org.apache.commons.lang3.StringUtils;" can be used like in the solution.