### PR TITLE
Update integrate-spa.md

### DIFF
--- a/help/headless-tutorial/spa-editor/react/integrate-spa.md
+++ b/help/headless-tutorial/spa-editor/react/integrate-spa.md
@@ -382,6 +382,9 @@ The initial set up of the mock JSON does **require a local AEM instance**.
     - REACT_APP_PAGE_MODEL_PATH=/content/wknd-spa-react/us/en.model.json
     + REACT_APP_PAGE_MODEL_PATH=/mock-content/mock.model.json
 
+    - REACT_APP_API_HOST=http://localhost:4502
+    + #REACT_APP_API_HOST=http://localhost:4502
+
     REACT_APP_ROOT=/content/wknd-spa-react/us/en/home.html
     ```
 


### PR DESCRIPTION
When trying out the "Bonus - Mock JSON API" steps, after changing the .env.development variables to point to local mock JSON content instead of AEM's en.model.json, and after restarting the webpack server, reloading shows only an empty space and a "http://localhost:4502/mock-content/mock.model.json not found" message in the console.  Commenting out the path to the API Host variable is necessary in order to see the live changes in the mock.model.json reflected in the page.