### PR TITLE
Update archetype version to latest

### DIFF
--- a/help/headless-tutorial/spa-editor/remote-spa/aem-configure.md
+++ b/help/headless-tutorial/spa-editor/remote-spa/aem-configure.md
@@ -33,7 +33,7 @@ $ cd ~/Code/wknd-app
 $ mvn -B archetype:generate \
  -D archetypeGroupId=com.adobe.aem \
  -D archetypeArtifactId=aem-project-archetype \
- -D archetypeVersion=27 \
+ -D archetypeVersion=35 \
  -D aemVersion=cloud \
  -D appTitle="WKND App" \
  -D appId="wknd-app" \


### PR DESCRIPTION
The aem project archetype 27 refers to spa project core version 1.3.0 which is not compatible with recent versions of the AEM.

```
<spa.project.core.version>1.3.0</spa.project.core.version>
```

To work with the SPA editor and remotepagenext at least version 1.3.8 seems to be required.