### PR TITLE
Mock port to 3000

### DIFF
--- a/help/headless-tutorial/spa-editor/react/integrate-spa.md
+++ b/help/headless-tutorial/spa-editor/react/integrate-spa.md
@@ -383,7 +383,7 @@ The initial set up of the mock JSON does **require a local AEM instance**.
     + REACT_APP_PAGE_MODEL_PATH=/mock-content/mock.model.json
 
     - REACT_APP_API_HOST=http://localhost:4502
-    + #REACT_APP_API_HOST=http://localhost:4502
+    + REACT_APP_API_HOST=http://localhost:3000
 
     REACT_APP_ROOT=/content/wknd-spa-react/us/en/home.html
     ```

--- a/help/headless-tutorial/spa-editor/react/integrate-spa.md
+++ b/help/headless-tutorial/spa-editor/react/integrate-spa.md
@@ -412,4 +412,5 @@ You can now toggle where to consume the JSON content by toggling the entries in 
 
 # JSON API via static mock file
 REACT_APP_PAGE_MODEL_PATH=/mock-content/mock.model.json
+REACT_APP_API_HOST=http://localhost:3000
 ```


### PR DESCRIPTION
The application doesn't load as it is looking for the `mock.model.json` on port 4502 which does not exist. Changing the variable `REACT_API_HOST` to port `3000` makes it work